### PR TITLE
seems there is no more --no-nat-upnp option for hcdev

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -3,4 +3,4 @@
 # try killing running server
 ps | grep "[h]cdev" | awk '{if($1!="") {print "killing process: "$1; system("kill " $1)}}'
 echo 'starting server'
-hcdev --no-nat-upnp web &
+hcdev web &


### PR DESCRIPTION
so then just following the README and trying to launch the stuff is failing.
